### PR TITLE
FP-9262 - Ember should create static IDs for HTML elements

### DIFF
--- a/addon/components/ebc-category.js
+++ b/addon/components/ebc-category.js
@@ -1,12 +1,13 @@
 import $ from 'jquery';
 import Component from '@ember/component';
 import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
 import { htmlSafe } from '@ember/string';
 import layout from '../templates/components/ebc-category';
 
 export default Component.extend({
   classNames: ['ebc-category'],
-  attributeBindings: ['customStyle:style'],
+  attributeBindings: ['customStyle:style', 'dataCy:data-cy'],
   layout,
   customStyle: computed('category.height', {
     get() {
@@ -14,6 +15,9 @@ export default Component.extend({
       return htmlSafe(`height:${height}px`);
     }
   }),
+
+  dataCy: alias('category.dataCy'),
+
   repaint(){
     let position = this.$().position();
     let borderTopWidth = Math.round(parseInt(this.$().css('border-top-width')));

--- a/addon/components/ebc-column.js
+++ b/addon/components/ebc-column.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { computed } from '@ember/object';
+import { alias } from '@ember/object/computed';
 import { htmlSafe } from '@ember/string';
 import layout from '../templates/components/ebc-column';
 
@@ -7,7 +8,7 @@ export default Ember.Component.extend({
   classNames: ['ebc-column'],
   layout,
   column: null,
-  attributeBindings: ['customStyle:style'],
+  attributeBindings: ['customStyle:style', 'dataCy:data-cy'],
   isFixed: false,
   customStyle: computed('column.width', 'board.columnHeight', 'board.fixedColumnHeight', {
     get() {
@@ -15,6 +16,7 @@ export default Ember.Component.extend({
       return htmlSafe(`min-width:${this.get('column.width')};height:${height}px`);
     }
   }),
+  dataCy: alias('column.dataCy'),
 
   cards: computed('column.cards', 'isFixed', {
     get() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-board-calendar",
-  "version": "0.0.2",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cli-board-calendar",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Ember CLI addon to create precise calendars",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
This PR aims to add data-cy elements to both vertical and horizontal columns to be interpreted by Cypress for the calculation of their X and Y axis's to pinpoint locations while doing click(x,y) in the testing tool. This is also adjoined by a similar PR in the mf-clinic-repo that assigns ids to those data-cy attributes.

![Screen Shot 2022-06-21 at 15 36 32](https://user-images.githubusercontent.com/140903/174876304-13a98f36-12ca-4741-b184-068f1c9c0b82.png)

![Screen Shot 2022-06-21 at 15 40 32](https://user-images.githubusercontent.com/140903/174876291-2293958f-f15d-4dad-9def-e8cc66a351b5.png)

